### PR TITLE
Use compileFormFields to build the fieldsets.

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -20,5 +20,6 @@
 /**
  * Hooks
  */
+$GLOBALS['TL_HOOKS']['initializeSystem'][] = array('ConditionalFormFields', 'registerHook');
 $GLOBALS['TL_HOOKS']['loadFormField'][] = array('ConditionalFormFields', 'loadFormField');
 $GLOBALS['TL_HOOKS']['outputFrontendTemplate'][] = array('ConditionalFormFields', 'outputFrontendTemplate');


### PR DESCRIPTION
Instead of loading the form fields from the database, I would like to use the `compileFormFields` hook instead. Then it would be possible to take account of manually injected fields from the `compileFormFields` hook. 

This requires that the custom fieldset hook would be the last in the chain. There's no garantee for that, but by using the `initializeSystem` hook to register, it will definitly come after all defined hooks in the `config.php` file of each module.