### PR TITLE
Feature/use compile form hook

### DIFF
--- a/ConditionalFormFields.php
+++ b/ConditionalFormFields.php
@@ -20,6 +20,67 @@
 
 class ConditionalFormFields extends Controller
 {
+    protected static $fieldsets;
+
+    /**
+     * Register hook when initializeSystem hook is triggerd.
+     */
+    public function registerHook()
+    {
+        $GLOBALS['TL_HOOKS']['compileFormFields'][] = array(__CLASS__, 'registerFieldsets');
+    }
+
+    /**
+     * Register fieldsets.
+     *
+     * @param \FormFieldModel[] $fieldModels
+     * @param string            $formSubmitId
+     * @param \Form             $objForm
+     *
+     * @return mixed
+     */
+    public function registerFieldsets($fieldModels, $formSubmitId, $objForm)
+    {
+        $formId = $objForm->id;
+        $fieldset = null;
+
+        static::$fieldsets[$formId] = array();
+
+        foreach ($fieldModels as $fieldModel) {
+
+            // Start the fieldset
+            if ($fieldModel->type == 'fieldset' && $fieldModel->fsType == 'fsStart' && $fieldModel->isConditionalFormField) {
+                $fieldset = $fieldModel->id;
+                $condition = $this->generateCondition($fieldModel->conditionalFormFieldCondition, 'php');
+
+                static::$fieldsets[$formId][$fieldset] = array(
+                    'condition' => function ($arrPost) use ($condition) {
+                        return eval($condition);
+                    },
+                    'fields' => array(),
+                );
+
+                // JS
+                $GLOBALS['CONDITIONALFORMFIELDS'][$formSubmitId][$fieldModel->id] = $fieldModel->conditionalFormFieldCondition;
+
+                continue;
+            }
+
+            // Stop the fieldset
+            if ($fieldModel->type == 'fieldset' && $fieldModel->fsType == 'fsStop') {
+                $fieldset = null;
+                continue;
+            }
+
+            if ($fieldset === null) {
+                continue;
+            }
+
+            static::$fieldsets[$formId][$fieldset]['fields'][] = $fieldModel->id;
+        }
+
+        return $fieldModels;
+    }
 
     /**
      * Apply conditional settings
@@ -33,9 +94,7 @@ class ConditionalFormFields extends Controller
      */
     public function loadFormField($objWidget, $formId, $arrForm, \Form $form)
     {
-        $fieldsets = $this->getConditionalFieldsets($arrForm['id'], $formId);
-
-        if (empty($fieldsets)) {
+        if (empty(static::$fieldsets[$form->id])) {
             return $objWidget;
         }
 
@@ -51,7 +110,7 @@ class ConditionalFormFields extends Controller
         if (\Input::post('FORM_SUBMIT') == $formId) {
             $postData = $this->getFormPostData($arrForm['id']);
 
-            foreach ($fieldsets as $fieldset) {
+            foreach (static::$fieldsets[$form->id] as $fieldset) {
                 foreach ($fieldset['fields'] as $fieldId) {
                     if ($fieldId == $objWidget->id && !$fieldset['condition']($postData)) {
                         $objWidget->mandatory = false;
@@ -88,63 +147,6 @@ class ConditionalFormFields extends Controller
         }
 
         return $data;
-    }
-
-    /**
-     * Get the conditional fieldsets with condition and fields
-     *
-     * @param int    $formId
-     * @param string $formSubmitId
-     *
-     * @return array
-     */
-    protected function getConditionalFieldsets($formId, $formSubmitId)
-    {
-        static $fieldsets;
-
-        if (!is_array($fieldsets[$formId])) {
-            $fieldsets[$formId] = array();
-            $fieldModels = \FormFieldModel::findPublishedByPid($formId);
-
-            if ($fieldModels !== null) {
-                $fieldset = null;
-
-                foreach ($fieldModels as $fieldModel) {
-
-                    // Start the fieldset
-                    if ($fieldModel->type == 'fieldset' && $fieldModel->fsType == 'fsStart' && $fieldModel->isConditionalFormField) {
-                        $fieldset = $fieldModel->id;
-                        $condition = $this->generateCondition($fieldModel->conditionalFormFieldCondition, 'php');
-
-                        $fieldsets[$formId][$fieldset] = array(
-                            'condition' => function ($arrPost) use ($condition) {
-                                return eval($condition);
-                            },
-                            'fields' => array(),
-                        );
-
-                        // JS
-                        $GLOBALS['CONDITIONALFORMFIELDS'][$formSubmitId][$fieldModel->id] = $fieldModel->conditionalFormFieldCondition;
-
-                        continue;
-                    }
-
-                    // Stop the fieldset
-                    if ($fieldModel->type == 'fieldset' && $fieldModel->fsType == 'fsStop') {
-                        $fieldset = null;
-                        continue;
-                    }
-
-                    if ($fieldset === null) {
-                        continue;
-                    }
-
-                    $fieldsets[$formId][$fieldset]['fields'][] = $fieldModel->id;
-                }
-            }
-        }
-
-        return $fieldsets[$formId];
     }
 
     /**

--- a/config/config.php
+++ b/config/config.php
@@ -20,5 +20,6 @@
 /**
  * Hooks
  */
+$GLOBALS['TL_HOOKS']['initializeSystem'][] = array('ConditionalFormFields', 'registerHook');
 $GLOBALS['TL_HOOKS']['loadFormField'][] = array('ConditionalFormFields', 'loadFormField');
 $GLOBALS['TL_HOOKS']['outputFrontendTemplate'][] = array('ConditionalFormFields', 'outputFrontendTemplate');


### PR DESCRIPTION
Instead of loading the form fields from the database, I would like to use the `compileFormFields` hook instead. Then it would be possible to take account of manually injected fields from the `compileFormFields` hook. 

This requires that the custom fieldset hook would be the last in the chain. There's no garantee for that, but by using the `initializeSystem` hook to register, it will definitly come after all defined hooks in the `config.php` file of each module.