### PR TITLE
added missing parameter to anonymous function

### DIFF
--- a/ConditionalFormFields.php
+++ b/ConditionalFormFields.php
@@ -54,7 +54,7 @@ class ConditionalFormFields extends Controller
                 $condition = $this->generateCondition($fieldModel->conditionalFormFieldCondition, 'php');
 
                 static::$fieldsets[$formId][$fieldset] = array(
-                    'condition' => function () use ($condition) {
+                    'condition' => function ($arrPost) use ($condition) {
                         return eval($condition);
                     },
                     'fields' => array(),


### PR DESCRIPTION
The anonymous function inside the `conditions` field of the static `$fieldsets`-array always returns `false` because of a missing parameter, so it validates invalid form fields.