### PR TITLE
disable Widget if field is disabled

### DIFF
--- a/ConditionalFormFields.php
+++ b/ConditionalFormFields.php
@@ -143,6 +143,9 @@ class ConditionalFormFields extends Controller
                     $errors = $reflection->getProperty('arrErrors');
                     $errors->setAccessible(true);
                     $errors->setValue($objWidget, []);
+                    
+                    // Widget needs to be set to disabled (#17)
+                    $objWidget->disabled = true;
                 }
             }
         }


### PR DESCRIPTION
See #17 and https://github.com/contao/core/pull/8707#issuecomment-297922914

If a form field has been disabled in the front end by _conditionalformfields_, the actual `Widget` also needs to be set to `disabled` - otherwise old session data might be processed in `processFormData`.