### PR TITLE
allow more than 255 characters for condition

### DIFF
--- a/dca/tl_form_field.php
+++ b/dca/tl_form_field.php
@@ -39,5 +39,5 @@ $GLOBALS['TL_DCA']['tl_form_field']['fields']['conditionalFormFieldCondition'] =
     'exclude'                 => true,
     'inputType'               => 'textarea',
     'eval'                    => array('mandatory'=>true, 'decodeEntities'=>true, 'style'=>'height:40px', 'tl_class'=>'clr'),
-    'sql'                     => "varchar(255) NOT NULL default ''",
+    'sql'                     => "text NULL",
 );


### PR DESCRIPTION
If your condition is more complex and the field name is long, the limit of `255` characters will be reached pretty soon. Also it's a `textarea` widget without a `maxlength`.