### PR TITLE
Contao 4.5 compatibility

### DIFF
--- a/ConditionalFormFields.php
+++ b/ConditionalFormFields.php
@@ -49,7 +49,7 @@ class ConditionalFormFields extends Controller
         foreach ($fieldModels as $fieldModel) {
 
             // Start the fieldset
-            if ($fieldModel->type == 'fieldset' && $fieldModel->fsType == 'fsStart' && $fieldModel->isConditionalFormField) {
+            if ((($fieldModel->type == 'fieldset' && $fieldModel->fsType == 'fsStart') || $fieldModel->type == 'fieldsetStart') && $fieldModel->isConditionalFormField) {
                 $fieldset = $fieldModel->id;
                 $condition = $this->generateCondition($fieldModel->conditionalFormFieldCondition, 'php');
 
@@ -67,7 +67,7 @@ class ConditionalFormFields extends Controller
             }
 
             // Stop the fieldset
-            if ($fieldModel->type == 'fieldset' && $fieldModel->fsType == 'fsStop') {
+            if ($fieldModel->type == 'fieldset' && $fieldModel->fsType == 'fsStop' || $fieldModel->type == 'fieldsetStop') {
                 $fieldset = null;
                 continue;
             }

--- a/dca/tl_form_field.php
+++ b/dca/tl_form_field.php
@@ -22,6 +22,7 @@
  */
 $GLOBALS['TL_DCA']['tl_form_field']['palettes']['__selector__'][] = 'isConditionalFormField';
 $GLOBALS['TL_DCA']['tl_form_field']['palettes']['fieldsetfsStart'] = str_replace('label;', 'label,isConditionalFormField;', $GLOBALS['TL_DCA']['tl_form_field']['palettes']['fieldsetfsStart']);
+$GLOBALS['TL_DCA']['tl_form_field']['palettes']['fieldsetStart'] = str_replace('label;', 'label,isConditionalFormField;', $GLOBALS['TL_DCA']['tl_form_field']['palettes']['fieldsetStart']);
 $GLOBALS['TL_DCA']['tl_form_field']['subpalettes']['isConditionalFormField'] = 'conditionalFormFieldCondition';
 
 $GLOBALS['TL_DCA']['tl_form_field']['fields']['isConditionalFormField'] = array


### PR DESCRIPTION
Currently this extension does not work in Contao `>=4.5`. There is no `fsType` in Contao 4.5 anymore, the fieldset start and strop wrapper have their own type and palette.

This PR makes simple changes to support both (Contao `<=4.4` and `>=4.5`).