### PR TITLE
do not replace "label;"

### DIFF
--- a/dca/tl_form_field.php
+++ b/dca/tl_form_field.php
@@ -21,8 +21,8 @@
  * Palettes
  */
 $GLOBALS['TL_DCA']['tl_form_field']['palettes']['__selector__'][] = 'isConditionalFormField';
-$GLOBALS['TL_DCA']['tl_form_field']['palettes']['fieldsetfsStart'] = str_replace('label;', 'label,isConditionalFormField;', $GLOBALS['TL_DCA']['tl_form_field']['palettes']['fieldsetfsStart']);
-$GLOBALS['TL_DCA']['tl_form_field']['palettes']['fieldsetStart'] = str_replace('label;', 'label,isConditionalFormField;', $GLOBALS['TL_DCA']['tl_form_field']['palettes']['fieldsetStart']);
+$GLOBALS['TL_DCA']['tl_form_field']['palettes']['fieldsetfsStart'] = str_replace(';{expert_legend', ',isConditionalFormField;{expert_legend', $GLOBALS['TL_DCA']['tl_form_field']['palettes']['fieldsetfsStart']);
+$GLOBALS['TL_DCA']['tl_form_field']['palettes']['fieldsetStart'] = str_replace(';{expert_legend', ',isConditionalFormField;{expert_legend', $GLOBALS['TL_DCA']['tl_form_field']['palettes']['fieldsetStart']);
 $GLOBALS['TL_DCA']['tl_form_field']['subpalettes']['isConditionalFormField'] = 'conditionalFormFieldCondition';
 
 $GLOBALS['TL_DCA']['tl_form_field']['fields']['isConditionalFormField'] = array


### PR DESCRIPTION
If an extension is loaded _before_ the conditionalformfields extension and that extension also adds new fields to the `fconfig_legend` of `tl_form_field`, e.g. via
```php
PaletteManipulator::create()
    ->addField('allowDuplication', 'fconfig_legend', PaletteManipulator::POSITION_APPEND)
    ->applyToPalette('fieldsetfsStart', 'tl_form_field');
```
then the palette change of conditionalformfields will not take place, since it currently replaces `'label;'` within the palette (see https://github.com/inspiredminds/contao-fieldset-duplication/issues/1).

A safer way (without using the PaletteManipulator) would be to insert new fields before the next legend, imho.