### PR TITLE
Fix overriding previous step data with actual POST data

### DIFF
--- a/ConditionalFormFields.php
+++ b/ConditionalFormFields.php
@@ -184,7 +184,7 @@ class ConditionalFormFields extends Controller
 
                 foreach ($fieldModels as $fieldModel) {
                     // Load post value with priority if available
-                    if ($_POST[$fieldModel->name]) {
+                    if (array_key_exists($fieldModel->name, $_POST)) {
                         $data[$fieldModel->name] = \Input::post($fieldModel->name);
                         continue;
                     }


### PR DESCRIPTION
I found two "strict `NULL` check issues" when using this extension with the mp_forms extension.

One issue with the client-side validation was fixed in https://github.com/terminal42/contao-conditionalformfields/commit/1963f218916179dbdae5fb81e8c09f1ecf2cd3f9#diff-20b7e700500d4b74252bd41332afe6bcb87e224a9990ff9c0bad87866dd9058eR143.

This PR fixes the other issue for the server-side validation.