### PR TITLE
Don't define strict mode globally

### DIFF
--- a/public/conditionalformfields.js
+++ b/public/conditionalformfields.js
@@ -1,6 +1,6 @@
-"use strict";
-
 (function () {
+    "use strict";
+ 
     const initialized = [];
 
     function init (node) {


### PR DESCRIPTION
I am not 100% sure - but I think if you define `"use strict";` this way, it would enable strict mode globally for all JavaScripts coming after it, which might potentially break other JavaScripts that do not adhere to strict mode. This PR would reduce the scope to the conditional form field JavaScript.