### PR TITLE
fix: return $fields if dummy form is used in FormListener

### DIFF
--- a/src/EventListener/FormListener.php
+++ b/src/EventListener/FormListener.php
@@ -43,6 +43,11 @@ class FormListener
             return $fields;
         }
 
+        if (empty($form->Template)) {
+            // The form template is not loaded yet
+            return $fields;
+        }
+
         if (!isset($this->handlers[$formId])) {
             $this->handlers[$formId] = new FormHandler($form, $fields, $this->expressionLanguageFactory->create(), $this->formManagerFactory);
         }


### PR DESCRIPTION
I use this bundle here in combination with `terminal42/contao-mp_forms`. If I have conditional fields in my form (e.g. on page 2 of the form) I get an error when I click on the button to proceed from page 1 to page 2 of the form.

I think the problem is like the following.

In the mp-forms bundle a DummyForm is created just before the first invocation of all `compileFormField` hooks (https://github.com/terminal42/contao-mp_forms/blob/6680f773cec00714dd21e953ed99d7c814d22ffd/src/FormManager.php#L381). This triggers the conditionalformfields `FormListener` and - as it's the first call for this `formId` creates a `FormHandler` with that DummyForm stored in it (https://github.com/terminal42/contao-conditionalformfields/blob/1d8240fa32e3b862d2ec62481a563181f57339e6/src/EventListener/FormListener.php#L47). This DummyForm doesn't have a instantiated `Template` and therefore the application crashes at https://github.com/terminal42/contao-conditionalformfields/blob/1d8240fa32e3b862d2ec62481a563181f57339e6/src/FormHandler.php#L75. Because `$this->form->Template` is null at this point.